### PR TITLE
Support M1 - Apple Silicon

### DIFF
--- a/TealiumAdobeVisitorAPI.podspec
+++ b/TealiumAdobeVisitorAPI.podspec
@@ -23,10 +23,6 @@ Pod::Spec.new do |s|
     s.platform     = :ios, "9.0"
     s.ios.deployment_target = "9.0"
 
-    # ――― Excluded Archs ―――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――― #
-    s.user_target_xcconfig = { 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'arm64' }
-    s.pod_target_xcconfig = { 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'arm64' }    
-
     # ――― Source Location ―――――――――――――――――――――――――――――――――――――――――――――――――――――――――― #
     s.source       = { :git => "https://github.com/Tealium/tealium-ios-adobe-visitor-api.git", :tag => "#{s.version}" }
     # s.source = { :git => "https://github.com/Tealium/tealium-ios-adobe-visitor-api.git", :branch => "main"}

--- a/TealiumAdobeVisitorAPI/TealiumAdobeVisitorAPI.podspec
+++ b/TealiumAdobeVisitorAPI/TealiumAdobeVisitorAPI.podspec
@@ -23,10 +23,6 @@ Pod::Spec.new do |s|
     s.platform     = :ios, "9.0"
     s.ios.deployment_target = "9.0"
 
-    # ――― Excluded Archs ―――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――― #
-    s.user_target_xcconfig = { 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'arm64' }
-    s.pod_target_xcconfig = { 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'arm64' }    
-
     # ――― Source Location ―――――――――――――――――――――――――――――――――――――――――――――――――――――――――― #
     s.source       = { :git => "https://github.com/Tealium/tealium-ios-adobe-visitor-api.git", :tag => "#{s.version}" }
 


### PR DESCRIPTION
## Issue:

We'd like to use arm64 instead of x86_64, we delete all exclude logic from our project configuration, but still meet below issue:

```
Could not find module 'TealiumAdobeVisitorAPI' for target 'x86_64-apple-ios-simulator'; found: arm64-apple-ios-simulator, at: xxx
```

## Root cause:

arm64 is excluded from podspec file

```
# ――― Excluded Archs ―――――――――――――――――――――――――――――――――――――――――――――――――――――――――――― #
s.user_target_xcconfig = { 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'arm64' }
s.pod_target_xcconfig = { 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'arm64' }    
```

## Solution:

Excluding arm64 will make the whole host project use x86_64 forcibly